### PR TITLE
Send arbitrary CCs before and after the Program Change

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ pip install -r requirements.txt
 Run `./samplescanner -h` for a full argument listing:
 
 ```contentsof<samplescanner -h>
-usage: samplescanner [-h] [--cc [CC [CC ...]]]
+usage: samplescanner [-h] [--cc-before [CC_BEFORE [CC_BEFORE ...]]]
+                     [--cc-after [CC_AFTER [CC_AFTER ...]]]
                      [--program-number PROGRAM_NUMBER] [--low-key LOW_KEY]
                      [--high-key HIGH_KEY]
                      [--velocity-levels VELOCITY_LEVELS [VELOCITY_LEVELS ...]]
@@ -50,8 +51,12 @@ optional arguments:
   -h, --help            show this help message and exit
 
 Sampling Options:
-  --cc [CC [CC ...]]    Send MIDI CC before starting. Separate CC# and value
-                        with a comma. Example: --cc "0,127" "64,65"
+  --cc-before [CC_BEFORE [CC_BEFORE ...]]
+                        Send MIDI CC before the program change. Put comma
+                        between CC# and value. Example: --cc 0,127 "64,65"
+  --cc-after [CC_AFTER [CC_AFTER ...]]
+                        Send MIDI CC after the program change. Put comma
+                        between CC# and value. Example: --cc 0,127 "64,65"
   --program-number PROGRAM_NUMBER
                         switch to a program number before recording
   --low-key LOW_KEY     key to start sampling from (key name, octave number)

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ pip install -r requirements.txt
 Run `./samplescanner -h` for a full argument listing:
 
 ```contentsof<samplescanner -h>
-usage: samplescanner [-h] [--program-number PROGRAM_NUMBER]
-                     [--low-key LOW_KEY] [--high-key HIGH_KEY]
+usage: samplescanner [-h] [--cc [CC [CC ...]]]
+                     [--program-number PROGRAM_NUMBER] [--low-key LOW_KEY]
+                     [--high-key HIGH_KEY]
                      [--velocity-levels VELOCITY_LEVELS [VELOCITY_LEVELS ...]]
                      [--key-skip KEY_RANGE] [--max-attempts MAX_ATTEMPTS]
                      [--limit LIMIT] [--has-portamento] [--sample-asc]
@@ -49,6 +50,8 @@ optional arguments:
   -h, --help            show this help message and exit
 
 Sampling Options:
+  --cc [CC [CC ...]]    Send MIDI CC before starting. Separate CC# and value
+                        with a comma. Example: --cc "0,127" "64,65"
   --program-number PROGRAM_NUMBER
                         switch to a program number before recording
   --low-key LOW_KEY     key to start sampling from (key name, octave number)

--- a/lib/midi_helpers.py
+++ b/lib/midi_helpers.py
@@ -14,6 +14,8 @@ class Midi(object):
 
     def cc(self, cc, val, channel=None):
         """Send a Continuous Controller change."""
+        cc = int(cc)
+        val = int(val)
         assert -1 < cc < 128
         assert -1 < val < 128
         print('Sending MIDI CC #{} with value {}.'.format(cc, val))

--- a/lib/midi_helpers.py
+++ b/lib/midi_helpers.py
@@ -6,6 +6,21 @@ CHANNEL_OFFSET = 0x90 - 1
 CC_CHANNEL_OFFSET = 0xB0 - 1
 
 
+class Midi(object):
+
+    def __init__(self, midi_out, channel=1):
+        self.midi = midi_out  # TODO Initialize rtmidi here, not outside
+        self.channel = channel
+
+    def cc(self, cc, val, channel=None):
+        """Send a Continuous Controller change."""
+        assert -1 < cc < 128
+        assert -1 < val < 128
+        print('Sending MIDI CC #{} with value {}.'.format(cc, val))
+        self.midi.send_message([
+            CC_CHANNEL_OFFSET + (channel or self.channel), cc, val])
+
+
 def all_notes_off(midiout, midi_channel):
     # All notes off
     midiout.send_message([

--- a/lib/send_notes.py
+++ b/lib/send_notes.py
@@ -138,8 +138,9 @@ def sample_program(
     midi_channel=1,
     midi_port_name=None,
     audio_interface_name=None,
-    midi_controllers=[],
+    cc_before=[],
     program_number=None,
+    cc_after=[],
     flac=True,
     velocity_levels=VELOCITIES,
     key_range=1,
@@ -179,9 +180,11 @@ def sample_program(
         regions = []
 
     midi = Midi(midiout, channel=midi_channel)
-    for cc in midi_controllers:  # Send out any MIDI controller changes
+    for cc in cc_before:  # Send out MIDI controller changes
         midi.cc(cc[0], cc[1])
     set_program_number(midiout, midi_channel, program_number)
+    for cc in cc_after:   # Send out MIDI controller changes
+        midi.cc(cc[0], cc[1])
 
     threshold = sample_threshold_from_noise_floor(
         bit_depth,

--- a/lib/send_notes.py
+++ b/lib/send_notes.py
@@ -138,9 +138,9 @@ def sample_program(
     midi_channel=1,
     midi_port_name=None,
     audio_interface_name=None,
-    cc_before=[],
+    cc_before=None,
     program_number=None,
-    cc_after=[],
+    cc_after=None,
     flac=True,
     velocity_levels=VELOCITIES,
     key_range=1,
@@ -180,10 +180,10 @@ def sample_program(
         regions = []
 
     midi = Midi(midiout, channel=midi_channel)
-    for cc in cc_before:  # Send out MIDI controller changes
+    for cc in cc_before or []:  # Send out MIDI controller changes
         midi.cc(cc[0], cc[1])
     set_program_number(midiout, midi_channel, program_number)
-    for cc in cc_after:   # Send out MIDI controller changes
+    for cc in cc_after or []:   # Send out MIDI controller changes
         midi.cc(cc[0], cc[1])
 
     threshold = sample_threshold_from_noise_floor(

--- a/lib/send_notes.py
+++ b/lib/send_notes.py
@@ -11,7 +11,7 @@ from constants import bit_depth, SAMPLE_RATE
 from volume_leveler import level_volume
 from flacize import flacize_after_sampling
 from loop import find_loop_points
-from midi_helpers import open_midi_port, set_program_number
+from midi_helpers import Midi, open_midi_port, set_program_number
 from audio_helpers import sample_threshold_from_noise_floor, \
     generate_sample, \
     check_for_clipping
@@ -138,6 +138,7 @@ def sample_program(
     midi_channel=1,
     midi_port_name=None,
     audio_interface_name=None,
+    midi_controllers=[],
     program_number=None,
     flac=True,
     velocity_levels=VELOCITIES,
@@ -177,6 +178,9 @@ def sample_program(
     except IOError:
         regions = []
 
+    midi = Midi(midiout, channel=midi_channel)
+    for cc in midi_controllers:  # Send out any MIDI controller changes
+        midi.cc(cc[0], cc[1])
     set_program_number(midiout, midi_channel, program_number)
 
     threshold = sample_threshold_from_noise_floor(

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -26,6 +26,11 @@ def note_number(note_name):
     return 21 + NOTE_NAMES.index(note) + (12 * octave_number)
 
 
+def two_ints(value):
+    key, val = value.split(',')
+    return (int(key), int(val))
+
+
 def warn_on_clipping(data, threshold=0.9999):
     if numpy.amax(numpy.absolute(data)) > ((2 ** (bit_depth - 1)) * threshold):
         print "WARNING: Clipping detected!"

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -27,6 +27,7 @@ def note_number(note_name):
 
 
 def two_ints(value):
+    """Type for argparse. Demands 2 integers separated by a comma."""
     key, val = value.split(',')
     return (int(key), int(val))
 

--- a/record.py
+++ b/record.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+
+"""Command-line interface for SampleScanner."""
+
 import argparse
 from lib.utils import note_number, two_ints
 from lib.send_notes import sample_program, VELOCITIES, MAX_ATTEMPTS
@@ -10,9 +13,13 @@ if __name__ == '__main__':
     )
     sampling_options = parser.add_argument_group('Sampling Options')
     sampling_options.add_argument(
-        '--cc', type=two_ints, help='Send MIDI CC before starting. '
-        'Separate CC# and value with a comma. Example: --cc "0,127" "64,65"',
-        nargs='*')
+        '--cc-before', type=two_ints, help='Send MIDI CC before the program '
+        'change. Put comma between CC# and value. Example: '
+        '--cc 0,127 "64,65"', nargs='*')
+    sampling_options.add_argument(
+        '--cc-after', type=two_ints, help='Send MIDI CC after the program '
+        'change. Put comma between CC# and value. Example: '
+        '--cc 0,127 "64,65"', nargs='*')
     sampling_options.add_argument(
         '--program-number', type=int,
         help='switch to a program number before recording')
@@ -87,8 +94,9 @@ if __name__ == '__main__':
         midi_channel=args.midi_channel,
         midi_port_name=args.midi_port_name,
         audio_interface_name=args.audio_interface_name,
-        midi_controllers=args.cc,
+        cc_before=args.cc_before,
         program_number=args.program_number,
+        cc_after=args.cc_after,
         flac=args.flac,
         velocity_levels=args.velocity_levels,
         key_range=args.key_range,

--- a/record.py
+++ b/record.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import argparse
-from lib.utils import note_number
+from lib.utils import note_number, two_ints
 from lib.send_notes import sample_program, VELOCITIES, MAX_ATTEMPTS
 
 
@@ -9,6 +9,10 @@ if __name__ == '__main__':
         description='create SFZ files from external audio devices'
     )
     sampling_options = parser.add_argument_group('Sampling Options')
+    sampling_options.add_argument(
+        '--cc', type=two_ints, help='Send MIDI CC before starting. '
+        'Separate CC# and value with a comma. Example: --cc "0,127" "64,65"',
+        nargs='*')
     sampling_options.add_argument(
         '--program-number', type=int,
         help='switch to a program number before recording')
@@ -83,6 +87,7 @@ if __name__ == '__main__':
         midi_channel=args.midi_channel,
         midi_port_name=args.midi_port_name,
         audio_interface_name=args.audio_interface_name,
+        midi_controllers=args.cc,
         program_number=args.program_number,
         flac=args.flac,
         velocity_levels=args.velocity_levels,


### PR DESCRIPTION
This pull request only implements a new argument that allows the user to send multiple Continuous Controller changes before sampling. EDIT: Now the pull request does more than this.

This could be used to remove reverb, control attack and release times, and also to access different banks of patches.

But please discuss with me, I think we should go even further and remove the CC that is being sent together with program change. Now I know that MIDI hardware varies wildly in the ways to access banks. Using the argument in this pull request is more effective.